### PR TITLE
💄 Adjust the scroll view bottom margin

### DIFF
--- a/src/screens/FoodList.js
+++ b/src/screens/FoodList.js
@@ -17,29 +17,6 @@ class FoodList extends Component {
     Actions.pop();
   }
 
-  /*<View style={styles.section}>
-    <View style={styles.sectionImgBox}>
-      <ImageBackground source={require('../images/Food/SaladBar.jpg')} style={styles.sectionImage}>
-        <Text style={styles.sectionTitle}>Salad Bar</Text>
-      </ImageBackground>
-    </View>
-    <View style={styles.sectionTextBox}>
-      <Text style={styles.sectionText}>Tomato Wedges</Text>
-    </View>
-    <View style={styles.sectionTextBox}>
-      <Text style={styles.sectionText}>Tossed Salad</Text>
-    </View>
-    <View style={styles.sectionTextBox}>
-      <Text style={styles.sectionText}>Broccoli Buds Op</Text>
-    </View>
-  </View>*/
-
-  /*<View style={styles.statusBar}>
-    <TouchableOpacity onPress={this.backToFood.bind(this)}>
-      <Text style={styles.statusBarButton}>Food</Text>
-    </TouchableOpacity>
-  </View>*/
-
   handleIndexChange = index => {
     this.props.foodTab(index);
   };
@@ -77,7 +54,7 @@ class FoodList extends Component {
             tabTextStyle={styles.tabTextStyle}
           />
         </View>
-        <ScrollView>
+        <ScrollView style={{ marginBottom: 75 }}>
           <View>{this.renderFoodLists()}</View>
         </ScrollView>
         <BottomBar hs={true} bus={true} fs={false} ls={true} mr={true} />

--- a/src/screens/RouteScreen.js
+++ b/src/screens/RouteScreen.js
@@ -36,7 +36,7 @@ export default class StopScreen extends Component {
             tabTextStyle={styles.tabTextStyle}
           />
         </View>
-        <ScrollView>
+        <ScrollView style={{ marginBottom: 75 }}>
           <View style={styles.viewStyle}>
             <Text style={styles.fontStyle}>Active Routes</Text>
             <TouchableOpacity

--- a/src/screens/StopScreen.js
+++ b/src/screens/StopScreen.js
@@ -51,7 +51,7 @@ class StopScreen extends Component {
             tabTextStyle={styles.tabTextStyle}
           />
         </View>
-        <ScrollView>
+        <ScrollView style={{ marginBottom: 75 }}>
           <View style={styles.viewStyle}>
             <Text style={styles.fontStyle}>Nearby</Text>
             <TouchableOpacity


### PR DESCRIPTION
For now, the height for bottom tab bar is hard coded as 75 px, so I added 75 px bottom margin for the scroll view so that it won't be covered by the bottom tab bar.

For later refactoring, the bottom tab bar height should depend on the device type. Referring to issue #4

Closes #52
