### PR TITLE
✨ Create prediction action for bus arrival time

### DIFF
--- a/src/actions/PredictionAction.js
+++ b/src/actions/PredictionAction.js
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import { PREDICTION, PREDICTION_DATA_HERE } from './types';
+
+export const getPrediction = (rid, sid) => {
+  if (rid == 'clean') {
+    return dispatch => {
+      dispatch({ type: PREDICTION, payload: [] });
+      dispatch({ type: PREDICTION_DATA_HERE, payload: 'no' });
+    };
+  }
+  const agency_id = '1323';
+  const base_url = 'https://transloc-api-1-2.p.rapidapi.com/';
+  const prediction_url =
+    base_url +
+    'arrival-estimates.json?routes=' +
+    rid.join('%2C') +
+    '&stops=' +
+    sid.join('%2C') +
+    '&agencies=' +
+    agency_id;
+  return dispatch => {
+    axios({
+      method: 'get',
+      url: prediction_url,
+      headers: {
+        Accept: 'application/json',
+        'X-Mashape-Key': 'Pcl9MfLNF0mshcAni8CgyFuxVXTap1NA0RxjsnoxN4439f9hBq',
+      },
+    }).then(response => {
+      prediction = response.data.data;
+      dispatch({ type: PREDICTION, payload: prediction });
+      dispatch({ type: PREDICTION_DATA_HERE, payload: 'here' });
+    });
+  };
+};

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,3 +2,4 @@ export * from './GeneralActions';
 export * from './HomeActions';
 export * from './FoodActions';
 export * from './BusActions';
+export * from './PredictionAction';

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -19,5 +19,7 @@ export const ALLBUS = 'allBus';
 export const ACTIVEROUTES = 'activeRoutes';
 export const INACTIVEROUTES = 'inactiveRoutes';
 export const BUS_DATA_HERE = 'bus_data_here';
+export const PREDICTION = 'prediction';
+export const PREDICTION_DATA_HERE = 'prediction_data_here';
 
 export const LINK_LIST = 'link_list';

--- a/src/reducers/BusReducer.js
+++ b/src/reducers/BusReducer.js
@@ -1,4 +1,12 @@
-import { NEARBYBUS, ALLBUS, ACTIVEROUTES, INACTIVEROUTES, BUS_DATA_HERE } from '../actions/types';
+import {
+  NEARBYBUS,
+  ALLBUS,
+  ACTIVEROUTES,
+  INACTIVEROUTES,
+  BUS_DATA_HERE,
+  PREDICTION,
+  PREDICTION_DATA_HERE,
+} from '../actions/types';
 
 const INITIAL_STATE = {
   nb_data: {},
@@ -6,6 +14,8 @@ const INITIAL_STATE = {
   active_data: {},
   inactive_data: {},
   data_here: 'no',
+  prediction: [],
+  has_prediction: 'no',
 };
 
 export default (state = INITIAL_STATE, action) => {
@@ -21,6 +31,10 @@ export default (state = INITIAL_STATE, action) => {
       return { ...state, inactive_data: action.payload };
     case BUS_DATA_HERE:
       return { ...state, data_here: action.payload };
+    case PREDICTION:
+      return { ...state, prediction: action.payload };
+    case PREDICTION_DATA_HERE:
+      return { ...state, has_prediction: action.payload };
     default:
       return state;
   }


### PR DESCRIPTION
`PREDICTION` + `PREDICTION_DATA_HERE` combo is specially designed to handle the data fetch delay.

Only after data arrived and `PREDICTION` is dispatched with data payload, `PREDICTION_DATA_HERE` would be then dispatched with 'here' payload.

When trying to clean the old data, `PREDICTION` is dispatched with an empty array as payload, and `PREDICTION_DATA_HERE` would be then dispatched with 'no' as payload.