### PR TITLE
✨ Reset tab bar icon counts and set status bar color from router

### DIFF
--- a/Router.js
+++ b/Router.js
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { setCounts } from './src/actions';
 import { Scene, Router, Modal } from 'react-native-router-flux';
 import TabIcon from './src/Components/TabIcon';
 import TodayScreen from './src/screens/TodayScreen';
@@ -19,9 +21,10 @@ import ClassSettingScreen from './src/screens/ClassSettingScreen';
 import SettingScreen from './src/screens/SettingScreen';
 import AboutMeScreen from './src/screens/AboutMeScreen';
 
-const RouterComponent = () => {
   return (
     <Router>
+class RouterComponent extends Component {
+  render() {
         <Modal key="modal" hideNavBar>
           <Scene key="root" hideNavBar>
             <Scene key="tabbar" tabs={true} activeTintColor="rgb(237,69,69)">
@@ -55,8 +58,18 @@ const RouterComponent = () => {
           <Scene key="classSetting_screen" component={ClassSettingScreen} hideNavBar />
           <Scene key="aboutMe_screen" component={AboutMeScreen} hideNavBar />
         </Modal>
-    </Router>
-  );
+      </Router>
+    );
+  }
+}
+
+const mapStateToProps = state => {
+  return {};
 };
 
-export default RouterComponent;
+export default connect(
+  mapStateToProps,
+  {
+    setCounts,
+  },
+)(RouterComponent);

--- a/Router.js
+++ b/Router.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
+import { Actions } from 'react-native-router-flux';
 import { connect } from 'react-redux';
+import { StatusBar } from 'react-native';
 import { setCounts } from './src/actions';
 import { Scene, Router, Modal } from 'react-native-router-flux';
 import TabIcon from './src/Components/TabIcon';
@@ -21,10 +23,26 @@ import ClassSettingScreen from './src/screens/ClassSettingScreen';
 import SettingScreen from './src/screens/SettingScreen';
 import AboutMeScreen from './src/screens/AboutMeScreen';
 
-  return (
-    <Router>
+const lightStatusBar = [
+  'stop',
+  'route',
+  'aboutMe_screen',
+  'sections_screen',
+  'section_detail_screen',
+];
+
 class RouterComponent extends Component {
   render() {
+    return (
+      <Router
+        onStateChange={() => {
+          if (lightStatusBar.includes(Actions.currentScene)) {
+            StatusBar.setBarStyle('light-content');
+          } else {
+            StatusBar.setBarStyle('dark-content');
+          }
+        }}
+      >
         <Modal key="modal" hideNavBar>
           <Scene key="root" hideNavBar>
             <Scene key="tabbar" tabs={true} activeTintColor="rgb(237,69,69)">

--- a/Router.js
+++ b/Router.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Scene, Router, Modal, Overlay, Lightbox } from 'react-native-router-flux';
+import { Scene, Router, Modal } from 'react-native-router-flux';
 import TabIcon from './src/Components/TabIcon';
 import TodayScreen from './src/screens/TodayScreen';
 import FavClassScreen from './src/screens/FavClassScreen';
@@ -22,43 +22,39 @@ import AboutMeScreen from './src/screens/AboutMeScreen';
 const RouterComponent = () => {
   return (
     <Router>
-      <Overlay key="overlay">
         <Modal key="modal" hideNavBar>
-          <Lightbox key="lightbox">
-            <Scene key="root" hideNavBar>
-              <Scene key="tabbar" tabs={true} activeTintColor="rgb(237,69,69)">
-                <Scene key="today" title="Today" icon={TabIcon}>
-                  <Scene key="today_screen" component={TodayScreen} hideNavBar />
-                </Scene>
-                <Scene key="bus" title="Bus" icon={TabIcon}>
-                  <Scene key="bus_screen" component={BusScreen} hideNavBar />
-                  <Scene key="stop" component={Stop} hideNavBar />
-                  <Scene key="route" component={Route} hideNavBar />
-                </Scene>
-                <Scene key="food" title="Food" icon={TabIcon}>
-                  <Scene key="food_screen" component={FoodScreen} hideNavBar />
-                  <Scene key="food_list" component={FoodList} hideNavBar />
-                </Scene>
-                <Scene key="links" title="Links" icon={TabIcon}>
-                  <Scene key="links_screen" component={LinkScreen} hideNavBar />
-                </Scene>
-                <Scene key="more" title="More" icon={TabIcon}>
-                  <Scene key="more_screen" component={MoreScreen} hideNavBar />
-                  <Scene key="setting_screen" component={SettingScreen} hideNavBar />
-                  <Scene key="subjects_screen" component={SubjectsScreen} hideNavBar />
-                  <Scene key="courses_screen" component={CoursesScreen} hideNavBar />
-                  <Scene key="sections_screen" component={SectionsScreen} hideNavBar />
-                  <Scene key="section_detail_screen" component={SectionDetailScreen} hideNavBar />
-                </Scene>
+          <Scene key="root" hideNavBar>
+            <Scene key="tabbar" tabs={true} activeTintColor="rgb(237,69,69)">
+              <Scene key="today" title="Today" icon={TabIcon}>
+                <Scene key="today_screen" component={TodayScreen} hideNavBar />
+              </Scene>
+              <Scene key="bus" title="Bus" icon={TabIcon}>
+                <Scene key="bus_screen" component={BusScreen} hideNavBar />
+                <Scene key="stop" component={Stop} hideNavBar />
+                <Scene key="route" component={Route} hideNavBar />
+              </Scene>
+              <Scene key="food" title="Food" icon={TabIcon}>
+                <Scene key="food_screen" component={FoodScreen} hideNavBar />
+                <Scene key="food_list" component={FoodList} hideNavBar />
+              </Scene>
+              <Scene key="links" title="Links" icon={TabIcon}>
+                <Scene key="links_screen" component={LinkScreen} hideNavBar />
+              </Scene>
+              <Scene key="more" title="More" icon={TabIcon}>
+                <Scene key="more_screen" component={MoreScreen} hideNavBar />
+                <Scene key="setting_screen" component={SettingScreen} hideNavBar />
+                <Scene key="subjects_screen" component={SubjectsScreen} hideNavBar />
+                <Scene key="courses_screen" component={CoursesScreen} hideNavBar />
+                <Scene key="sections_screen" component={SectionsScreen} hideNavBar />
+                <Scene key="section_detail_screen" component={SectionDetailScreen} hideNavBar />
               </Scene>
             </Scene>
-          </Lightbox>
+          </Scene>
           <Scene key="favClass_screen" component={FavClassScreen} hideNavBar />
           <Scene key="favBus_screen" component={FavBusScreen} hideNavBar />
           <Scene key="classSetting_screen" component={ClassSettingScreen} hideNavBar />
           <Scene key="aboutMe_screen" component={AboutMeScreen} hideNavBar />
         </Modal>
-      </Overlay>
     </Router>
   );
 };

--- a/Router.js
+++ b/Router.js
@@ -36,6 +36,9 @@ class RouterComponent extends Component {
     return (
       <Router
         onStateChange={() => {
+          if (Actions.currentScene == 'today_screen') {
+            this.props.setCounts(0);
+          }
           if (lightStatusBar.includes(Actions.currentScene)) {
             StatusBar.setBarStyle('light-content');
           } else {


### PR DESCRIPTION
From the router level, we can still call redux actions. But leave `mapStateToProps` empty to avoid infinite loop on updating the redux store and reloading the page.

Closes #156 
Closes #139